### PR TITLE
Fixed the problem introduced with #1

### DIFF
--- a/limessystemadapter.docker
+++ b/limessystemadapter.docker
@@ -4,8 +4,6 @@ ADD target/SpatialBenchmark-1.0-SNAPSHOT.jar /SpatialBenchmark/SpatialBenchmark.
 
 WORKDIR /SpatialBenchmark
 
-COPY lib/* /SpatialBenchmark/lib/
-
 COPY datasets/* /SpatialBenchmark/datasets/
 
 COPY configs/topologicalConfigs/* /SpatialBenchmark/configs/topologicalConfigs/

--- a/silksystemadapter.docker
+++ b/silksystemadapter.docker
@@ -6,7 +6,7 @@ WORKDIR /SpatialBenchmark
 
 COPY datasets/* /SpatialBenchmark/datasets/
 
-COPY lib/* /SpatialBenchmark/lib/
+COPY repository/com/vividsolutions/jts/silk/0.1/silk-0.1.jar /SpatialBenchmark/lib/silk.jar
 
 COPY configs/topologicalConfigs/* /SpatialBenchmark/configs/topologicalConfigs/
 

--- a/spatialdatagenerator.docker
+++ b/spatialdatagenerator.docker
@@ -4,8 +4,6 @@ ADD target/SpatialBenchmark-1.0-SNAPSHOT.jar /SpatialBenchmark/SpatialBenchmark.
 
 WORKDIR /SpatialBenchmark
 
-COPY lib/* /SpatialBenchmark/lib/
-
 COPY test.properties /SpatialBenchmark/
 
 COPY definitions.properties /SpatialBenchmark/

--- a/src/main/java/org/hobbit/spatialbenchmark/platformConnection/DataGenerator.java
+++ b/src/main/java/org/hobbit/spatialbenchmark/platformConnection/DataGenerator.java
@@ -67,7 +67,7 @@ public class DataGenerator extends AbstractDataGenerator {
         reInitializeProperties();
 
         // call mimicking algorithm
-//        runMimicking();
+        runMimicking();
 
         task = new Task(Integer.toString(taskId++), null, null, null);
 
@@ -344,8 +344,8 @@ public class DataGenerator extends AbstractDataGenerator {
 
     public void runMimicking() {
         LOGGER.info("Running mimicking algorithm ");
-//        DockerBasedMimickingAlg alg = new DockerBasedMimickingAlg(this, "git.project-hobbit.eu:4567/filipe.teixeira/synthetic-trace-generator");
-        DockerBasedMimickingAlg alg = new DockerBasedMimickingAlg(this, "git.project-hobbit.eu:4567/filipe.teixeira/synthetic-trace-generator/64kb-traces");
+        DockerBasedMimickingAlg alg = new DockerBasedMimickingAlg(this, "git.project-hobbit.eu:4567/filipe.teixeira/synthetic-trace-generator");
+//        DockerBasedMimickingAlg alg = new DockerBasedMimickingAlg(this, "git.project-hobbit.eu:4567/filipe.teixeira/synthetic-trace-generator/64kb-traces");
 
         try {
             String[] TomTomDataArguments = new String[3];

--- a/src/main/java/org/hobbit/spatialbenchmark/platformConnection/DataGenerator.java
+++ b/src/main/java/org/hobbit/spatialbenchmark/platformConnection/DataGenerator.java
@@ -67,7 +67,7 @@ public class DataGenerator extends AbstractDataGenerator {
         reInitializeProperties();
 
         // call mimicking algorithm
-        runMimicking();
+//      runMimicking();
 
         task = new Task(Integer.toString(taskId++), null, null, null);
 
@@ -344,8 +344,8 @@ public class DataGenerator extends AbstractDataGenerator {
 
     public void runMimicking() {
         LOGGER.info("Running mimicking algorithm ");
-        DockerBasedMimickingAlg alg = new DockerBasedMimickingAlg(this, "git.project-hobbit.eu:4567/filipe.teixeira/synthetic-trace-generator");
-//        DockerBasedMimickingAlg alg = new DockerBasedMimickingAlg(this, "git.project-hobbit.eu:4567/filipe.teixeira/synthetic-trace-generator/64kb-traces");
+//        DockerBasedMimickingAlg alg = new DockerBasedMimickingAlg(this, "git.project-hobbit.eu:4567/filipe.teixeira/synthetic-trace-generator");
+        DockerBasedMimickingAlg alg = new DockerBasedMimickingAlg(this, "git.project-hobbit.eu:4567/filipe.teixeira/synthetic-trace-generator/64kb-traces");
 
         try {
             String[] TomTomDataArguments = new String[3];


### PR DESCRIPTION
This pull request fixes the problem that the docker images couldn't be build after moving the silk jar file from `lib` to `repository`.